### PR TITLE
Removal of `keepersecurity.com`

### DIFF
--- a/0.0.0.0/hosts
+++ b/0.0.0.0/hosts
@@ -5802,7 +5802,6 @@ fe80::1%lo0 localhost
 0.0.0.0 www.kazatube.com
 0.0.0.0 www.keandra.com
 0.0.0.0 www.keep2share.cc
-0.0.0.0 www.keepersecurity.com
 0.0.0.0 www.keezlive.com
 0.0.0.0 www.keezmovies.com
 0.0.0.0 www.keismindwarp.com

--- a/127.0.0.1/hosts
+++ b/127.0.0.1/hosts
@@ -5802,7 +5802,6 @@ fe80::1%lo0 localhost
 127.0.0.1 www.kazatube.com
 127.0.0.1 www.keandra.com
 127.0.0.1 www.keep2share.cc
-127.0.0.1 www.keepersecurity.com
 127.0.0.1 www.keezlive.com
 127.0.0.1 www.keezmovies.com
 127.0.0.1 www.keismindwarp.com

--- a/Mobile_0_0_0_0/hosts
+++ b/Mobile_0_0_0_0/hosts
@@ -5792,7 +5792,6 @@ fe80::1%lo0 localhost
 0.0.0.0 m.kazatube.com
 0.0.0.0 m.keandra.com
 0.0.0.0 m.keep2share.cc
-0.0.0.0 m.keepersecurity.com
 0.0.0.0 m.keezlive.com
 0.0.0.0 m.keezmovies.com
 0.0.0.0 m.keismindwarp.com

--- a/SafeSearch/hosts
+++ b/SafeSearch/hosts
@@ -5999,7 +5999,6 @@ fe80::1%lo0 localhost
 0.0.0.0 www.kazatube.com
 0.0.0.0 www.keandra.com
 0.0.0.0 www.keep2share.cc
-0.0.0.0 www.keepersecurity.com
 0.0.0.0 www.keezlive.com
 0.0.0.0 www.keezmovies.com
 0.0.0.0 www.keismindwarp.com


### PR DESCRIPTION
Closes https://github.com/Clefspeare13/pornhosts/issues/105

Originally posted by @salevdns I haven't been able to see any reason to keep this record at all, any bad things related to this domain happens via Rakuten and [linkshare.com](https://www.mypdns.org/T697)

Forcing this PR without first approval by @Clefspeare13 but he are most welcome to redo my action if he find that necessary 