### PR TITLE
vamateur.com

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -1,3 +1,5 @@
+www.vamateur.com
+vamateur.com
 0013langford.tumblr.com
 007angels.com
 00webcams.com


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that have to 
be blocked as..

```python
www.vamateur.com
vamateur.com
```

## Comments
vamateur.com is also used but redirects to www.vamateur.com
## Screenshots

<details><Summary>Screenshot required</summary>

![vamateur1](https://user-images.githubusercontent.com/20802412/89711615-bb8f3080-d961-11ea-9d0c-8100d9cce6f4.png)
![vamateur3](https://user-images.githubusercontent.com/20802412/89711616-bd58f400-d961-11ea-91c4-7c88c23cb312.png)
![vamateur2](https://user-images.githubusercontent.com/20802412/89711699-3ce6c300-d962-11ea-8d47-ffb71c190e6e.jpg)


</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->



### All Submissions:
- [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [x] Added ScreenDump for prove of False Positive

### Todo
- [ ] Added to [Source file](submit_here/hosts.txt)?
