### PR TITLE
afterschool.jp

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -1,3 +1,5 @@
+www.afterschool.jp
+cdn.afterschool.jp
 0013langford.tumblr.com
 007angels.com
 00webcams.com


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that have to 
be blocked as..

```python
www.afterschool.jp
cdn.afterschool.jp
```

## Comments

## Screenshots

<details><Summary>Screenshot required</summary>

![afterschool1](https://user-images.githubusercontent.com/20802412/89889430-f97d9600-dba7-11ea-9b2d-488a91818ef2.png)
![afterschool2](https://user-images.githubusercontent.com/20802412/89889432-fb475980-dba7-11ea-96b9-99abb6ffd39d.png)
![afterschool3](https://user-images.githubusercontent.com/20802412/89889434-fbdff000-dba7-11ea-891b-3cefda10c745.png)


</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->



### All Submissions:
- [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [x] Added ScreenDump for prove of False Positive

### Todo
- [ ] Added to [Source file](submit_here/hosts.txt)?
