### PR TITLE
japanhdv.com

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -1,3 +1,6 @@
+japanhdv.com
+static.japanhdv.com
+trailers.japanhdv.com
 0013langford.tumblr.com
 007angels.com
 00webcams.com


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that have to 
be blocked as..

```python
japanhdv.com
static.japanhdv.com
trailers.japanhdv.com
```

## Comments

## Screenshots

<details><Summary>Screenshot required</summary>

![japanhdv1](https://user-images.githubusercontent.com/20802412/91624350-36060b80-e976-11ea-8e1b-c135b1dc8bef.jpg)
![japanhdv2](https://user-images.githubusercontent.com/20802412/91624352-37373880-e976-11ea-971e-3ad71974ae65.png)
![japanhdv3](https://user-images.githubusercontent.com/20802412/91624353-37cfcf00-e976-11ea-9561-5eb2b6c0209a.png)


</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->



### All Submissions:
- [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [x] Added ScreenDump for prove of False Positive

### Todo
- [ ] Added to [Source file](submit_here/hosts.txt)?
- [ ] Added to the RPZ zone [adult.mypdns.cloud](https://www.mypdns.org/w/rpzlist/#adult-mypdns-cloud) (@spirillen)
