### PR TITLE
covertjapan.com

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -1,3 +1,5 @@
+www.covertjapan.com
+free.covertjapan.com
 0013langford.tumblr.com
 007angels.com
 00webcams.com


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that have to 
be blocked as..

```python
www.covertjapan.com
free.covertjapan.com
```

## Comments
free.covertjapan.com might look like a different domain, but www.covertjapan.com depend on it to work
## Screenshots

<details><Summary>Screenshot required</summary>

![covertjapan1](https://user-images.githubusercontent.com/20802412/91624700-17087900-e978-11ea-8ec8-ba33292d9ed7.png)
![covertjapan2](https://user-images.githubusercontent.com/20802412/91624701-1839a600-e978-11ea-9795-7875ee67a61d.png)
![covertjapan3](https://user-images.githubusercontent.com/20802412/91624702-1839a600-e978-11ea-8b80-0bf10ceec551.png)
![covertjapan4](https://user-images.githubusercontent.com/20802412/91624703-18d23c80-e978-11ea-9983-968bcf4203b8.png)


</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->



### All Submissions:
- [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [x] Added ScreenDump for prove of False Positive

### Todo
- [ ] Added to [Source file](submit_here/hosts.txt)?
- [ ] Added to the RPZ zone [adult.mypdns.cloud](https://www.mypdns.org/w/rpzlist/#adult-mypdns-cloud) (@spirillen)
