### PR TITLE
b-cdn.net

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -1,3 +1,4 @@
+hookuphotshotpublic.b-cdn.net
 0013langford.tumblr.com
 007angels.com
 00webcams.com


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that have to 
be blocked as..

```python
hookuphotshotpublic.b-cdn.net
```

## Comments
part of https://github.com/Clefspeare13/pornhosts/pull/199
## Screenshots

<details><Summary>Screenshot required</summary>



</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->



### All Submissions:
- [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [ ] Added ScreenDump for prove of False Positive

### Todo
- [x] Added to [Source file](submit_here/hosts.txt)?
- [x] Added to the RPZ zone [adult.mypdns.cloud](https://www.mypdns.org/w/rpzlist/#adult-mypdns-cloud) (@spirillen)
