### PR TITLE
giga-web.jp

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -1,3 +1,4 @@
+www.giga-web.jp
 0013langford.tumblr.com
 007angels.com
 00webcams.com


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that have to 
be blocked as..

```python
www.giga-web.jp
```

## Comments
part of https://github.com/Clefspeare13/pornhosts/pull/226
## Screenshots

<details><Summary>Screenshot required</summary>

![giga1](https://user-images.githubusercontent.com/20802412/91747710-0aad3780-eb95-11ea-9e71-6decde70c717.png)
![giga2](https://user-images.githubusercontent.com/20802412/91747712-0bde6480-eb95-11ea-8a40-6d22de5da1e9.png)


</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->



### All Submissions:
- [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [x] Added ScreenDump for prove of False Positive

### Todo
- [ ] Added to [Source file](submit_here/hosts.txt)?
- [ ] Added to the RPZ zone [adult.mypdns.cloud](https://www.mypdns.org/w/rpzlist/#adult-mypdns-cloud) (@spirillen)
