### PR TITLE
r18.video

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -1,3 +1,4 @@
+r18.video
 0013langford.tumblr.com
 007angels.com
 00webcams.com


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that have to be blocked as..

```python
r18.video
```

## Comments

## Screenshots
<!-- keep one clean above and below image link. Otherwise the collapseble feature breaks -->

<details><Summary>Screenshot required</summary>


</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->

![r181](https://user-images.githubusercontent.com/20802412/92071854-37747100-ed86-11ea-9296-474ca7b2f1e5.jpg)
![r182](https://user-images.githubusercontent.com/20802412/92071857-38a59e00-ed86-11ea-8711-48f2678d5823.png)


### All Submissions:
- [ ] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [ ] Added ScreenDump for prove of False Positive

### Todo
- [ ] Added to [Source file](submit_here/hosts.txt)?
- [ ] Added to the RPZ zone [adult.mypdns.cloud](https://www.mypdns.org/w/rpzlist/#adult-mypdns-cloud) (@spirillen)
