### PR TITLE
paradisehill.cc

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -3976,6 +3976,7 @@ rummp.com
 rumrunners.us
 runawayangels.com
 runetki2.com
+ru.paradisehill.cc
 ru.porn.com
 ru.pornhub.com
 ru.redtube.com


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that have to be blocked as..

```python
ru.paradisehill.cc
```

## Comments
The site is already in the list as `en.paradisehill.cc`. This is the version in Russian.

## Screenshots
<!-- keep one clean above and below image link. Otherwise the collapseble feature breaks -->

<details><Summary>Screenshot required</summary>


</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->



### All Submissions:
- [ ] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [ ] Added ScreenDump for prove of False Positive

### Todo
- [ ] Added to [Source file](submit_here/hosts.txt)?
- [ ] Added to the RPZ zone [adult.mypdns.cloud](https://www.mypdns.org/w/rpzlist/#adult-mypdns-cloud) (@spirillen)
