### PR TITLE
biqle.com, .com domain added at the EOF as per guidelines

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -12939,3 +12939,4 @@ zzbabes.com
 zzgays.com
 zzitube.com
 zzztube.com
+biqle.com


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that has to be blocked as..

```python
biqle.com
www.biqle.com
```

## Comments
Only the `.ru` domain of the site was previously included, but users could still access the site through the `.com` domain.
I have simply added it's `.com` domain to hosts.txt.\
\
New line added at EOF as per the contribution guidelines.

</details>

## Screenshots

I'm confused on this part, do I include the screenshot of the website or the part where I have changed the code?
The `.ru` domain of the site was already included previously, so additional checks might not be required.
Nonetheless, here is a [screenshot](https://camo.githubusercontent.com/c8407c0803ed16993360b5086130661144bc8e7c90138dba387b295a8776a035/68747470733a2f2f7265706f7274732d696d672e616467756172642e636f6d2f6e4f325841516f2e6a7067) of the site from another github repository.

### All Submissions:
- [X] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [x] Added ScreenDump for prove of False Positive
